### PR TITLE
task/bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,14 +42,14 @@
     "babel-eslint": "~10.0.0",
     "babel-jest": "~24.8.0",
     "babel-loader": "~8.0.0",
-    "eslint": "~6.5.0",
+    "eslint": "~6.6.0",
     "eslint-config-airbnb-base": "~14.0.0",
     "eslint-import-resolver-webpack": "~0.11.0",
     "eslint-loader": "~3.0.0",
     "eslint-plugin-flowtype": "~4.3.0",
     "eslint-plugin-import": "~2.18.0",
-    "eslint-plugin-jest": "~22.19.0",
-    "flow-bin": "~0.109.0",
+    "eslint-plugin-jest": "~23.0.0",
+    "flow-bin": "~0.110.0",
     "immutable": "4.0.0-rc.12",
     "jest": "~24.8.0",
     "npm-run-all": "~4.1.0",
@@ -57,7 +57,7 @@
     "uuid": "~3.3.0",
     "webpack": "~4.41.0",
     "webpack-cli": "~3.3.0",
-    "webpack-dev-server": "~3.8.0"
+    "webpack-dev-server": "~3.9.0"
   },
   "peerDependencies": {
     "@babel/polyfill": "~7.6.0",


### PR DESCRIPTION
# Changes
- Add getEntityKeyIds Watcher/Worker/Actions to DataIntegrationApi
- Bump dependencies
  - eslint: "~6.6.0",
  - eslint-plugin-jest: "~23.0.0",
  - flow-bin: "~0.110.0",
  - webpack-dev-server: "~3.9.0"